### PR TITLE
✨ feat: manual_only 결과 지원을 위한 Playwright manual fixture를 지원한다

### DIFF
--- a/core/test-coverage/index.ts
+++ b/core/test-coverage/index.ts
@@ -1,4 +1,9 @@
-import { TResultStatus } from "../test-registry";
+import {
+  TResultStatus,
+  TResultWithDescription,
+  TTestSuiteId,
+  TTestCaseId,
+} from "../test-registry";
 import { GoogleSpreadsheetsContract } from "../google-spreadsheets";
 
 type TestCoverageContract = {
@@ -92,23 +97,26 @@ class TestCoverage implements TestCoverageContract {
     };
   }
 
-  #calculateSuiteStats(caseMap: Map<TTestCaseId, TResultStatus>) {
+  #calculateSuiteStats(caseMap: Map<TTestCaseId, TResultWithDescription>) {
     const scenarios = new Set<string>();
     let executedCount = 0;
     let passCount = 0;
     const statusCounts = this.#emptyStatusCount();
 
-    caseMap.forEach((status, testId) => {
-      scenarios.add(this.#scenarioIdOf(testId));
-      statusCounts[status] += 1;
+    for (const [testCaseId, result] of caseMap) {
+      const status = result.status;
+      const scenarioId = this.#scenarioIdOf(testCaseId);
+      scenarios.add(scenarioId);
+
+      statusCounts[status]++;
 
       if (this.#isExecuted(status)) {
-        executedCount += 1;
+        executedCount++;
         if (this.#isSuccess(status)) {
-          passCount += 1;
+          passCount++;
         }
       }
-    });
+    }
 
     return {
       scenarioCount: scenarios.size,
@@ -180,11 +188,13 @@ export type {
   TOverallSummary,
   TSuiteSummary,
   TTestCoverageResults,
+  TResultsPerSuite,
 };
 
-type TTestSuiteId = string;
-type TTestCaseId = string;
-type TResultsPerSuite = Map<TTestSuiteId, Map<TTestCaseId, TResultStatus>>;
+type TResultsPerSuite = Map<
+  TTestSuiteId,
+  Map<TTestCaseId, TResultWithDescription>
+>;
 type TStatusCount = Record<TResultStatus, number>;
 
 type TOverallSummary = {

--- a/core/test-registry/index.ts
+++ b/core/test-registry/index.ts
@@ -179,4 +179,5 @@ class TestRegistry implements TestRegistryContract {
   }
 }
 
-export { TestRegistry, type TestRegistryContract, type TResultStatus };
+export { TestRegistry };
+export * from "./types";

--- a/core/test-registry/index.ts
+++ b/core/test-registry/index.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs-extra";
-import { TResultStatus } from "./types";
+import { TResultStatus, TResultWithDescription } from "./types";
 import { GoogleSpreadsheetsContract } from "../google-spreadsheets";
 import { ResultsMatrix } from "./results-matrix";
 import { TTestCaseId, TTestSuiteId } from "./types";
@@ -7,10 +7,10 @@ import chalk from "chalk";
 
 type TestRegistryContract = {
   logResults(
-    resultsPerSuite: Map<TTestSuiteId, Map<TTestCaseId, TResultStatus>>
+    resultsPerSuite: Map<TTestSuiteId, Map<TTestCaseId, TResultWithDescription>>
   ): Promise<void>;
   resultsPerSuite(): Promise<
-    Map<TTestSuiteId, Map<TTestCaseId, TResultStatus>>
+    Map<TTestSuiteId, Map<TTestCaseId, TResultWithDescription>>
   >;
 };
 
@@ -29,7 +29,7 @@ class TestRegistry implements TestRegistryContract {
   }
 
   async logResults(
-    resultsPerSuite: Map<TTestSuiteId, Map<TTestCaseId, TResultStatus>>
+    resultsPerSuite: Map<TTestSuiteId, Map<TTestCaseId, TResultWithDescription>>
   ): Promise<void> {
     const suitesMeta = await this.#googleSpreadsheets.suitesMeta();
 
@@ -49,7 +49,7 @@ class TestRegistry implements TestRegistryContract {
   }
 
   async resultsPerSuite(): Promise<
-    Map<TTestSuiteId, Map<TTestCaseId, TResultStatus>>
+    Map<TTestSuiteId, Map<TTestCaseId, TResultWithDescription>>
   > {
     const json = await this.#json();
     const base = this.#matrix.resultsPerSuite(json);
@@ -71,7 +71,7 @@ class TestRegistry implements TestRegistryContract {
 
       tcIdsInSheet.forEach((tcId) => {
         if (!bucket.has(tcId)) {
-          bucket.set(tcId, "not_executed");
+          bucket.set(tcId, { status: "not_executed" });
         }
       });
 
@@ -84,7 +84,7 @@ class TestRegistry implements TestRegistryContract {
   /** 시트 한 개에 대한 결과 기록 전체 프로세스 */
   async #writeSuiteResults(
     sheet: ReturnType<GoogleSpreadsheetsContract["testSuiteSheet"]>,
-    resultPerTestId: Map<string, TResultStatus>
+    resultPerTestId: Map<string, TResultWithDescription>
   ) {
     if (resultPerTestId.size === 0) return;
 
@@ -95,8 +95,8 @@ class TestRegistry implements TestRegistryContract {
     // (1) 결과값 배열 생성
     const resultValues: string[][] = dataRows.map((row: any[]) => {
       const testId: string = row[sheet.columnNumberOf("testId")] ?? "";
-      const status = resultPerTestId.get(testId);
-      return [status ? this.#matrix.labelOf(status) : ""];
+      const result = resultPerTestId.get(testId);
+      return [result ? this.#matrix.labelOf(result.status) : ""];
     });
 
     // (2) 헤더 + 결과 합치기 후 작성
@@ -123,6 +123,31 @@ class TestRegistry implements TestRegistryContract {
       rows.length,
       colIdx
     );
+
+    // (3) manual_only에 대한 description을 comment로 추가
+    await this.#addManualOnlyComments(sheet, resultPerTestId, colIdx);
+  }
+
+  /** manual_only에 대한 description을 comment로 추가 */
+  async #addManualOnlyComments(
+    sheet: ReturnType<GoogleSpreadsheetsContract["testSuiteSheet"]>,
+    resultPerTestId: Map<string, TResultWithDescription>,
+    colIdx: number
+  ) {
+    const rows = await sheet.rows();
+    const testIdCol = sheet.columnNumberOf("testId");
+
+    for (let rowIdx = 2; rowIdx < rows.length; rowIdx++) {
+      // 헤더 2줄 제외
+      const testId = rows[rowIdx][testIdCol] as string;
+      if (!testId) continue;
+
+      const result = resultPerTestId.get(testId);
+      if (result?.status === "manual_only" && result.description) {
+        // comment 추가 (rowIdx는 0-based, 시트는 1-based이므로 +1)
+        await sheet.addComment(rowIdx + 1, colIdx + 1, result.description);
+      }
+    }
   }
 
   /** 결과 컬럼 인덱스(0-base) 계산 */

--- a/core/test-registry/types.ts
+++ b/core/test-registry/types.ts
@@ -7,3 +7,8 @@ export type TResultStatus =
   | "flaky"
   | "not_executed"
   | "manual_only";
+
+export type TResultWithDescription = {
+  status: TResultStatus;
+  description?: string;
+};

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "peerDependencies": {
     "@msw/playwright": "^0.4.2",
-    "@playwright/test": ">=1.30.0",
+    "@playwright/test": "^1.52.0",
     "detox": ">=20.0.0"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
       "types": "./dist/packages/playwright/reporter.d.ts"
     }
   },
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Google 스프레드시트 기반 시나리오를 Playwright 테스트 스텁 코드로 자동 생성하고, 테스트 실행 결과를 다시 시트에 업데이트하는 CLI 도구",
   "files": [
     "dist/**/*",

--- a/packages/playwright/fixtures/manual-fixture.ts
+++ b/packages/playwright/fixtures/manual-fixture.ts
@@ -1,7 +1,7 @@
 import { test as base } from "@playwright/test";
 
 type TFixtures = {
-  manual: (title: string, reason: string) => Promise<void>;
+  manual: (title: string, reason?: string) => Promise<void>;
 };
 
 /**
@@ -9,7 +9,7 @@ type TFixtures = {
  */
 const manualTest = base.extend<TFixtures>({
   manual: async ({}, use) => {
-    await use(async (title: string, reason: string) => {
+    await use(async (title: string, reason?: string) => {
       // (1) TC ID 추출 – "[TC-x.x]" 형태를 파싱한다.
       const match = title.match(/\[(TC-[\d.]+)]/);
       const testId = match ? match[1] : "";
@@ -18,7 +18,7 @@ const manualTest = base.extend<TFixtures>({
       await base.step(title, async () => {
         base.info().annotations.push({
           type: "manual_only",
-          description: `${testId}|${reason}`,
+          description: `${testId}|${reason ?? ""}`,
         });
       });
     });

--- a/packages/playwright/fixtures/manual-fixture.ts
+++ b/packages/playwright/fixtures/manual-fixture.ts
@@ -1,0 +1,28 @@
+import { test as base } from "@playwright/test";
+
+type TFixtures = {
+  manual: (title: string, reason: string) => Promise<void>;
+};
+
+/**
+ * 시트에 manual_only 결과를 지원하기 위한 fixture입니다.
+ */
+const manualTest = base.extend<TFixtures>({
+  manual: async ({}, use) => {
+    await use(async (title: string, reason: string) => {
+      // (1) TC ID 추출 – "[TC-x.x]" 형태를 파싱한다.
+      const match = title.match(/\[(TC-[\d.]+)]/);
+      const testId = match ? match[1] : "";
+
+      // (2) Playwright step 등록 + 커스텀 annotation 기록
+      await base.step(title, async () => {
+        base.info().annotations.push({
+          type: "manual_only",
+          description: `${testId}|${reason}`,
+        });
+      });
+    });
+  },
+});
+
+export { manualTest };

--- a/packages/playwright/fixtures/merged-test.ts
+++ b/packages/playwright/fixtures/merged-test.ts
@@ -1,0 +1,8 @@
+import { mergeTests } from "@playwright/test";
+
+import { manualTest } from "./manual-fixture";
+import { mswScenarioTest } from "./msw-scenario-fixture";
+
+const test = mergeTests(mswScenarioTest, manualTest);
+
+export { test };

--- a/packages/playwright/index.ts
+++ b/packages/playwright/index.ts
@@ -1,5 +1,4 @@
-export * from "./fixtures/msw-scenario-fixture";
-export * from "./fixtures/manual-fixture";
+export * from "./fixtures/merged-test";
 
 import E2EAutogenPlaywrightReporter from "./reporter";
 export default E2EAutogenPlaywrightReporter;

--- a/packages/playwright/index.ts
+++ b/packages/playwright/index.ts
@@ -1,4 +1,5 @@
-export { mswScenarioTest } from "./fixtures/msw-scenario-fixture";
+export * from "./fixtures/msw-scenario-fixture";
+export * from "./fixtures/manual-fixture";
 
 import E2EAutogenPlaywrightReporter from "./reporter";
 export default E2EAutogenPlaywrightReporter;

--- a/packages/playwright/reporter.ts
+++ b/packages/playwright/reporter.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   FullConfig,
   TestResult as PlaywrightTestResult,
   Reporter,

--- a/packages/playwright/reporter.ts
+++ b/packages/playwright/reporter.ts
@@ -31,10 +31,9 @@ class E2EAutogenPlaywrightReporter implements Reporter {
       test.titlePath().find((t) => t.includes("TC-")) || test.title;
     const description = removeTestIdFromTitle(specTitle);
 
-    const manualSteps = getManualSteps().filter((s) =>
+    const manualSteps = extractManualSteps(result).filter((s) =>
       s.testId.startsWith(scenarioId)
     );
-    resetManualSteps();
 
     // Step 분석
     const flakySteps = getFlakyStepTitles(result);
@@ -241,12 +240,20 @@ type TManualStep = {
   description: string;
 };
 
-const manualSteps: TManualStep[] = [];
-
-const getManualSteps = () => manualSteps;
-const resetManualSteps = () => {
-  manualSteps.length = 0;
-};
+/**
+ * result.annotations 에 기록된 manual_only 정보를 추출한다.
+ * description 형식: `${testId}|${reason}`
+ */
+function extractManualSteps(result: PlaywrightTestResult): TManualStep[] {
+  const annotations = (result as any).annotations ?? [];
+  return annotations
+    .filter((a: any) => a.type === "manual_only")
+    .map((a: any) => {
+      const [testId, ...descParts] = (a.description ?? "").split("|");
+      return { testId, description: descParts.join("|") } as TManualStep;
+    })
+    .filter((m: TManualStep) => m.testId);
+}
 
 function updateSpecClassification(spec: TSpecGroup) {
   // 초기화


### PR DESCRIPTION
## ✨ 작업 배경 [#](#background) <span id="background"></span>

Playwright에서 manual_only 테스트 케이스를 지원하고, 결과를 Google Sheets에 comment로 기록하기 위한 작업입니다.

✔️ Related issues #14 
- Close #14 

## 💻 작업 내용 [#](#work_detail) <span id="work_detail"></span>
### manual fixture 제공

```ts
import { test } from '@dhlab/e2e-autogen/playwright';

test('[TC-3.7] 로그인한 사용자의 기록이 아닐 때 노출되는 버튼 확인', async ({ manual }) => {
  await manual(
    '[TC-3.7.1] 다른 사용자 페이지 로드 ->00 버튼을 출력하지 않는다',
    '다른 사용자 기록을 조작하지 못하므로 자동화 불가'
  );
});
```

### Reporter 처리
manual_only 결과가 다음과 같이 처리됩니다:
```json
"manual_only": [
  ["TC-3.7.1", "다른 사용자 기록을 조작하지 못하므로 자동화 불가"]
]
```

### 통합 Fixture 지원
기존에는 프로젝트에서 merge해서 사용해야 했지만, 이제 `e2e-autogen`에서 제공하는 fixture들을 merge해서 `import { test } from '@dhlab/e2e-autogen'`으로 사용하도록 지원합니다.

### Google Sheets Comment 자동 추가
`manual_only` 테스트 케이스의 description이 Google Sheets의 해당 셀에 comment로 자동 추가되어, 마우스 오버 시 설명을 확인할 수 있습니다.

## 🏃 기능 동작 시연 [#](#prove) <span id="prove"></span>

- comment에 description 추가된 모습

<img width="365" height="230" alt="스크린샷 2025-08-01 오후 2 03 57" src="https://github.com/user-attachments/assets/44a6c6f7-687e-4f4e-a014-3e1918ec97a8" />


## 💬 코멘트 [#](#comments) <span id="comments"></span>

<!-- 리뷰어에게 전달하고 싶은 사항, 리뷰 시 확인해야 하는 사항 등-->
