### PR TITLE
✨ feat: 오디오 파일/사인파로 마이크 입력을 모킹하는 fixture를 추가한다

### DIFF
--- a/packages/playwright/fixtures/merged-test.ts
+++ b/packages/playwright/fixtures/merged-test.ts
@@ -1,9 +1,55 @@
 import { mergeTests } from "@playwright/test";
 
 import { manualTest } from "./manual-fixture";
+import { recordingTest } from "./recording-fixture";
 
 // import { mswScenarioTest } from "./msw-scenario-fixture";
 
-const test = mergeTests(manualTest);
+/**
+ * 통합 Playwright 테스트 엔트리입니다. 아래 여러 픽스처가 병합된 `test`를 제공합니다.
+ *
+ * 1) manual 픽스처
+ * - 목적: 특정 스텝을 수동 검증(manual_only)로 기록합니다.
+ * - 시그니처: manual(title: string, reason?: string): Promise<void>
+ * - 사용 예:
+ *   ```ts
+ *   import { test } from '@dhlab/e2e-autogen/playwright';
+ *
+ *   test('수동 검증 예시', async ({ manual }) => {
+ *     await manual('[TC-1.1] 수동 검증 필요', 'UI 명확성 확인');
+ *   });
+ *   ```
+ *
+ * 2) recording 픽스처
+ * - 목적: 실제 마이크 대신 로컬 오디오 파일 또는 사인파를 getUserMedia로 주입합니다.
+ * - 옵션: test.use({ audioFilePath?: string })
+ *   - 지정 시 해당 파일을 1회 재생하는 오디오 스트림을 반환합니다.
+ *   - 미지정 시 440Hz 사인파 스트림을 반환합니다.
+ * - 라우팅: 내부 URL(`/_e2e-audio_/파일명`)만 가로채 로컬 파일을 응답하므로 서버 트래픽에는 영향이 없습니다.
+ * - 권한: 브라우저 컨텍스트에 마이크 권한을 자동 허용합니다.
+ * - 사용 예:
+ *   ```ts
+ *   import path from 'node:path';
+ *   import { test } from '@dhlab/e2e-autogen/playwright';
+ *   import { expect } from '@playwright/test';
+ *
+ *   test.use({
+ *     audioFilePath: path.join(process.cwd(), 'public', 'audio', 'demo-3sec.wav'),
+ *   });
+ *
+ *   test('[TC-4.2] 녹음 중 메모 입력', async ({ page, setupRecording, startNewRecording }) => {
+ *     // 권장 순서: 페이지 진입 → 모킹 주입 → 녹음 트리거
+ *     await page.goto('/main', { waitUntil: 'networkidle' });
+ *     await setupRecording();
+ *     await startNewRecording();
+ *     // ... 검증 로직
+ *   });
+ *   ```
+ *
+ * 사용 시 주의사항
+ * - 반드시 이 파일이 export하는 `test`를 사용하세요. (예: `import { test } from '@dhlab/e2e-autogen/playwright'`)
+ * - iframe 등 별도 문맥에서 getUserMedia를 호출한다면, 해당 프레임이 로드된 이후에 `setupRecording()`을 다시 호출해 패치를 보장하세요.
+ */
+const test = mergeTests(manualTest, recordingTest);
 
 export { test };

--- a/packages/playwright/fixtures/recording-fixture.ts
+++ b/packages/playwright/fixtures/recording-fixture.ts
@@ -1,0 +1,96 @@
+/// <reference lib="dom" />
+import path from "node:path";
+import { test as base, type Page } from "@playwright/test";
+
+type TFixtures = {
+  audioFilePath?: string;
+  setupRecording: () => Promise<void>;
+};
+
+const recordingTest = base.extend<TFixtures>({
+  // 로컬 오디오 파일 경로 (없으면 사인파)
+  audioFilePath: [undefined, { option: true }],
+
+  setupRecording: async ({ page, audioFilePath }, use) => {
+    await use(async () => {
+      if (audioFilePath) {
+        const fileUrl = `/_e2e-audio_/${path.basename(audioFilePath)}`;
+        await mockMediaDevices(page, { fileUrl, filePath: audioFilePath });
+      } else {
+        await mockMediaDevices(page);
+      }
+    });
+  },
+});
+
+export { recordingTest };
+
+const mockMediaDevices = async (
+  page: Page,
+  {
+    enabled = true,
+    fileUrl,
+    filePath,
+  }: { enabled?: boolean; fileUrl?: string; filePath?: string } = {}
+) => {
+  // 옵션에 따라 모킹 스킵
+  if (!enabled) return;
+
+  // 마이크 권한 허용 - Chrome/Chromium인 경우만
+  const browserName = page.context().browser()?.browserType().name();
+  if (browserName === "chromium") {
+    await page.context().grantPermissions(["microphone"]);
+  }
+
+  // 오디오 파일 라우팅 설정 (요청된 URL을 로컬 파일로 응답)
+  if (fileUrl && filePath) {
+    await page.route("**/_e2e-audio_/*", async (route) => {
+      try {
+        const requested = new URL(route.request().url());
+        const requestedBase = path.basename(requested.pathname);
+        const expectedBase = path.basename(fileUrl);
+        if (requestedBase === expectedBase) {
+          await route.fulfill({
+            path: filePath,
+            headers: { "content-type": "audio/wav" },
+          });
+          return;
+        }
+      } catch {}
+      await route.fallback();
+    });
+  }
+
+  await page.evaluate(async (url) => {
+    navigator.mediaDevices.getUserMedia = async () => {
+      const audioContext = new AudioContext();
+      const destination = audioContext.createMediaStreamDestination();
+
+      if (url) {
+        // 외부 WAV 파일을 fetch 후 단발 재생
+        const response = await fetch(url);
+        const arrayBuffer = await response.arrayBuffer();
+        const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+
+        const bufferSource = audioContext.createBufferSource();
+        bufferSource.buffer = audioBuffer;
+        bufferSource.connect(destination);
+        bufferSource.start(0); // loop 기본 false -> 1회 재생
+      } else {
+        // 사인파 모킹 (기존 로직)
+        const oscillator = audioContext.createOscillator();
+        const gainNode = audioContext.createGain();
+
+        oscillator.frequency.setValueAtTime(440, audioContext.currentTime);
+        oscillator.type = "sine";
+        gainNode.gain.setValueAtTime(0.1, audioContext.currentTime);
+
+        oscillator.connect(gainNode);
+        gainNode.connect(destination);
+        oscillator.start();
+      }
+
+      return destination.stream;
+    };
+  }, fileUrl);
+};


### PR DESCRIPTION
## ✨ 작업 배경 [#](#background) <span id="background"></span>

- 실제 마이크 입력을 수반하는 녹음/전사 플로우는 E2E 자동화가 어렵습니다. 
- 매 테스트마다 수동 발화를 반복하는 것은 번거롭고, 환경 잡음·권한 이슈로 결과가 불안정합니다.

**목표:**
- 실제 마이크 없이도 항상 동일한 오디오로 녹음 기능을 자동 검증하고, CI에서도 안정적으로 재현.
- 이를 fixture로 제공하여 손쉽게 녹음 테스트를 구현할 수 있도록 함.

✔️ Related issues #33 

## 💻 작업 내용 [#](#work_detail) <span id="work_detail"></span>

- 테스트할 때마다 직접 말할 수 없으므로, 준비된 오디오 파일을 주입해 입력을 제공합니다.
- `navigator.mediaDevices.getUserMedia`를 테스트 시에만 오버라이드하여 두 가지 입력을 제공합니다:
  - 로컬 오디오 파일 1회 재생으로 생성한 MediaStream (전사 내용까지 검증할 때)
  - `440Hz 사인파`(음성은 여러 사인파의 합으로 표현되므로) MediaStream (내용 무관, 마이크 모킹만 필요할 때) 

- 위 과정을 Playwright 픽스처로 캡슐화하여, 테스트에서는 옵션(`audioFilePath`) 하나로 재현 가능한 “가짜 마이크 입력”을 손쉽게 주입합니다.

```mermaid
sequenceDiagram
  autonumber
  participant Consumer as Consumer Test File
  participant Fix as Recording Fixture
  participant Page as Playwright Page
  participant Route as page.route
  participant FS as Local FileSystem
  participant App as Web App (Recorder)
  participant Media as navigator.mediaDevices
  participant AC as AudioContext

  Consumer->>Fix: test.use({ audioFilePath })
  Note over Fix: 옵션 저장 (audioFilePath)
  Consumer->>Page: page.goto('/main', { waitUntil: 'networkidle' })
  Consumer->>Fix: setupRecording()

  Note right of Page: if Chromium → grantPermissions('microphone')
  Fix->>Page: route('**/_e2e-audio_/*' → fulfill from FS)
  Fix->>Page: evaluate(override getUserMedia with '/_e2e-audio_/basename')

  App->>Media: getUserMedia({ audio: true })
  Media->>AC: createMediaStreamDestination()

  alt audioFilePath provided
    Page->>Route: fetch('/_e2e-audio_/file.wav')
    Route->>FS: read file.wav
    FS-->>Route: wav bytes
    Route-->>Page: 200 audio/wav
    AC->>AC: decodeAudioData → createBufferSource → start(0)
  else no audioFilePath
    AC->>AC: createOscillator(440Hz) → gain(0.1) → start()
  end

  AC-->>Media: destination.stream
  Media-->>App: MediaStream
  App->>App: record / transcribe / save
  Consumer->>Consumer: assertions
```

## 🏃 사용 가이드 [#](#prove) <span id="prove"></span>
```tsx
import { test } from '@dhlab/e2e-autogen/playwright';

// public/audio/demo.wav 주입
test.use({
  audioFilePath: path.join(process.cwd(), 'public', 'audio', 'demo.wav'),
});

test('[TC-4.2] 녹음 중 메모 입력', async ({ page, setupRecording }) => {
   // 권장 순서: 페이지 진입 → 모킹 주입 → 녹음 트리거
   await page.goto('/main', { waitUntil: 'networkidle' });
   await setupRecording();
   await startNewRecording();
   // ... 검증 로직
});
```
